### PR TITLE
fix: include pointing twice to the same directory

### DIFF
--- a/packages/shared/vitest.config.js
+++ b/packages/shared/vitest.config.js
@@ -5,7 +5,7 @@ const PACKAGE_ROOT = __dirname;
 
 const config = {
   test: {
-    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', '../shared/**/*.{test,spec}.?(c|m)[jt]s?(x)']
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)']
   },
   resolve: {
     alias: {


### PR DESCRIPTION
The two paths in `include` represent the same pattern, as `../shared` is the same as `.` 